### PR TITLE
fix: Modify signals to use new async format

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -680,9 +680,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.2.tgz",
-      "integrity": "sha512-vluaspfvWEtE4vcSDlKRNer52DvOGrB2xv6diXy6UKyKW0lqZiWHGNApSyxOv+8DE5Z27IzVvE7hNkxg7EXIcg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.4.tgz",
+      "integrity": "sha512-5kz9ScmzBdzTgB/3susoCgfqNDzBjvLL4taparufgSvlwjdLy6UyUy9T/tCpYd2GIdIilCatC4iSQS0QSYHt0w==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -718,9 +718,9 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "@types/lodash": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A=="
     },
     "@types/mime": {
       "version": "1.3.5",
@@ -728,9 +728,9 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "@types/node": {
-      "version": "22.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
       "requires": {
         "undici-types": "~6.20.0"
       }
@@ -1331,15 +1331,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "bluebird": {
       "version": "3.7.2",
@@ -2415,9 +2406,9 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-uri": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
-      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.5.tgz",
+      "integrity": "sha512-5JnBCWpFlMo0a3ciDy/JckMzzv1U9coZrIhedq+HXxxUfDTAiS0LA8OKVao4G9BxmCVck/jtA5r3KAtRWEyD8Q=="
     },
     "fastest-levenshtein": {
       "version": "1.0.16",
@@ -2445,12 +2436,6 @@
         "loader-utils": "^2.0.0",
         "schema-utils": "^3.0.0"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "optional": true
     },
     "fill-range": {
       "version": "7.1.1",
@@ -2615,20 +2600,29 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
-      "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
       "requires": {
         "call-bind-apply-helpers": "^1.0.1",
-        "dunder-proto": "^1.0.0",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
         "function-bind": "^1.1.2",
+        "get-proto": "^1.0.0",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
-        "math-intrinsics": "^1.0.0"
+        "math-intrinsics": "^1.1.0"
+      }
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
       }
     },
     "get-stream": {
@@ -2820,9 +2814,9 @@
       }
     },
     "http-parser-js": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
-      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q=="
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.9.tgz",
+      "integrity": "sha512-n1XsPy3rXVxlqxVioEWdC+0+M+SQw0DpJynwtOPo1X+ZlvdzTLtDBIJJlDQTnwZIFJrZSzSGmIOUdP8tu+SgLw=="
     },
     "http-proxy": {
       "version": "1.18.1",
@@ -2997,9 +2991,9 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-core-module": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.0.tgz",
-      "integrity": "sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "requires": {
         "hasown": "^2.0.2"
       }
@@ -3434,12 +3428,6 @@
         "thunky": "^1.0.2"
       }
     },
-    "nan": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
-      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
-      "optional": true
-    },
     "nanoid": {
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
@@ -3475,7 +3463,7 @@
     },
     "newsroom-core": {
       "version": "github:superdesk/newsroom-core#1ba1e4d875bef936267f959528900d6b54a20efe",
-      "from": "github:superdesk/newsroom-core#1ba1e4d875bef936267f959528900d6b54a20efe",
+      "from": "github:superdesk/newsroom-core#feature/multiple-events-in-planning",
       "requires": {
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/sortable": "^8.0.0",
@@ -3924,9 +3912,9 @@
       "integrity": "sha512-KDeO94CbWI4pKsPnYpA1FPjo79EsY9I+M8ywoPBSf9XMXoe/0crjbUK7jcQEDHuc0ZMRIZsxH3TYLv4TUtHmAA=="
     },
     "primereact": {
-      "version": "10.8.5",
-      "resolved": "https://registry.npmjs.org/primereact/-/primereact-10.8.5.tgz",
-      "integrity": "sha512-B1LeJdNGGAB8P1VRJE0TDYz6rZSDwxE7Ft8PLFjRYLO44+mIJNDsLYSB56LRJOoqUNRhQrRIe/5ctS5eyQAzwQ==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/primereact/-/primereact-10.9.1.tgz",
+      "integrity": "sha512-mq5Pr6/zySO913RlL5oUWD+n1ygTjJjhhxBoRWhLNKx7Na8pHpswh/QCesShFXlfYyCjDOVXFVT6J2sSDceF1g==",
       "requires": {
         "@types/react-transition-group": "^4.4.1",
         "react-transition-group": "^4.4.1"
@@ -4196,20 +4184,20 @@
       }
     },
     "react-router": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.28.0.tgz",
-      "integrity": "sha512-HrYdIFqdrnhDw0PqG/AKjAqEqM7AvxCz0DQ4h2W8k6nqmc5uRBYDag0SBxx9iYz5G8gnuNVLzUe13wl9eAsXXg==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.28.1.tgz",
+      "integrity": "sha512-2omQTA3rkMljmrvvo6WtewGdVh45SpL9hGiCI9uUrwGGfNFDIvGK4gYJsKlJoNVi6AQZcopSCballL+QGOm7fA==",
       "requires": {
         "@remix-run/router": "1.21.0"
       }
     },
     "react-router-dom": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.28.0.tgz",
-      "integrity": "sha512-kQ7Unsl5YdyOltsPGl31zOjLrDv+m2VcIEcIHqYYD3Lp0UppLjrzcfJqDJwXxFw3TH/yvapbnUvPlAj7Kx5nbg==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.28.1.tgz",
+      "integrity": "sha512-YraE27C/RdjcZwl5UCqF/ffXnZDxpJdk9Q6jw38SZHjXs7NNdpViq2l2c7fO7+4uWaEfcwfGCv3RSg4e1By/fQ==",
       "requires": {
         "@remix-run/router": "1.21.0",
-        "react-router": "6.28.0"
+        "react-router": "6.28.1"
       }
     },
     "react-sortable-hoc": {
@@ -5534,11 +5522,7 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/server/dev-requirements.txt
+++ b/server/dev-requirements.txt
@@ -4,6 +4,7 @@ flake8
 pytest==8.3.3
 pytest-cov==5.0.0
 pytest-mock==3.14.0
+pytest-asyncio
 responses>=0.10.6,<0.26
 httmock
 wooper

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -53,9 +53,9 @@ blinker==1.8.2
     #   quart
     #   sentry-sdk
     #   superdesk-core
-boto3==1.35.85
+boto3==1.35.96
     # via superdesk-core
-botocore==1.35.85
+botocore==1.35.96
     # via
     #   boto3
     #   s3transfer
@@ -67,7 +67,7 @@ cachetools==5.5.0
     #   google-auth
 celery[redis]==5.4.0
     # via superdesk-core
-cerberus==1.3.5
+cerberus==1.3.7
     # via
     #   eve
     #   superdesk-core
@@ -83,11 +83,11 @@ chardet==5.2.0
     # via
     #   reportlab
     #   superdesk-core
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 ciso8601==2.3.2
     # via eve-elastic
-click==8.1.7
+click==8.1.8
     # via
     #   celery
     #   click-didyoumean
@@ -201,7 +201,7 @@ itsdangerous==2.2.0
     #   flask
     #   flask-oidc-ex
     #   quart
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   flask
     #   quart
@@ -277,7 +277,7 @@ pyasn1-modules==0.4.1
     #   oauth2client
 pycparser==2.22
     # via cffi
-pydantic==2.10.4
+pydantic==2.10.5
     # via superdesk-core
 pydantic-core==2.27.2
     # via pydantic
@@ -296,7 +296,7 @@ pymongo==4.9.2
     #   eve
     #   motor
     #   superdesk-core
-pyparsing==3.2.0
+pyparsing==3.2.1
     # via
     #   httplib2
     #   pyrtf3
@@ -404,7 +404,7 @@ superdesk-planning @ git+https://github.com/superdesk/superdesk-planning.git@asy
     # via newsroom-core
 svglib==1.5.1
     # via xhtml2pdf
-taskgroup==0.2.1
+taskgroup==0.2.2
     # via hypercorn
 tinycss2==1.4.0
     # via
@@ -412,11 +412,11 @@ tinycss2==1.4.0
     #   svglib
 tomli==2.2.1
     # via hypercorn
-types-aiofiles==24.1.0.20240626
+types-aiofiles==24.1.0.20241221
     # via quart-uploads
 types-python-dateutil==2.9.0.20241206
     # via arrow
-types-pytz==2024.2.0.20241003
+types-pytz==2024.2.0.20241221
     # via quart-babel
 typing-extensions==4.12.2
     # via

--- a/server/settings.py
+++ b/server/settings.py
@@ -6,13 +6,13 @@ from newsroom.types import AuthProviderType
 from newsroom.web.default_settings import (
     ELASTICSEARCH_SETTINGS,
     CONTENTAPI_ELASTICSEARCH_SETTINGS,
-    BLUEPRINTS as DEFAULT_BLUEPRINT,
     CORE_APPS as DEFAULT_CORE_APPS,
     CELERY_BEAT_SCHEDULE as CELERY_BEAT_SCHEDULE_DEFAULT,
     CLIENT_LOCALE_FORMATS,
     AUTH_PROVIDERS,
     WIRE_TIME_FILTERS,
     AGENDA_SEARCH_FIELDS,
+    MODULES as DEFAULT_MODULES,
 )
 
 SERVER_PATH = pathlib.Path(__file__).resolve().parent
@@ -123,14 +123,11 @@ CORE_APPS = [
     ]
 ]
 
-BLUEPRINTS = [
-    blueprint
-    for blueprint in DEFAULT_BLUEPRINT
-    if blueprint
-    not in [
-        "newsroom.monitoring",
-    ]
-]
+MODULES = [
+    module
+    for module in DEFAULT_MODULES
+    if module not in ["newsroom.wire.module", "newsroom.monitoring.module"]
+] + ["stt.wire"]
 
 LANGUAGES = ["fi", "en"]
 DEFAULT_LANGUAGE = "fi"

--- a/server/setup.cfg
+++ b/server/setup.cfg
@@ -8,7 +8,7 @@ confcutdir = tests
 addopts = --tb=short
 
 [mypy]
-python_version = 3.8
+python_version = 3.10
 allow_untyped_globals = True
 ignore_missing_imports = True
 

--- a/server/setup.cfg
+++ b/server/setup.cfg
@@ -6,6 +6,8 @@ exclude = env,venv,node_modules,build
 testpaths = tests
 confcutdir = tests
 addopts = --tb=short
+asyncio_mode=auto
+asyncio_default_fixture_loop_scope=function
 
 [mypy]
 python_version = 3.10

--- a/server/stt/filters.py
+++ b/server/stt/filters.py
@@ -1,26 +1,30 @@
-import superdesk
-
-from superdesk.resource import not_analyzed
-from newsroom.signals import publish_item
-from eve_elastic.elastic import parse_date
+from typing import Any
 from copy import copy
+
+from eve_elastic.elastic import parse_date
+
+from newsroom.signals import publish_item
+
+from .wire import STTWireItem
+
 
 STT_NESTED_FIELDS = ["sttdepartment", "sttversion"]
 STT_ROOT_FIELDS = ["sttgenre", "sttdone1"]
 STT_FIELDS = STT_NESTED_FIELDS + STT_ROOT_FIELDS
 
 
-def get_previous_version(app, guid, version):
+async def get_previous_version(guid: str, version: str) -> STTWireItem | None:
+    service = STTWireItem.get_service()
     for i in range(int(version) - 1, 1, -1):
-        id = "{}:{}".format(guid, i)
-        original = app.data.find_one("items", req=None, _id=id)
+        version_id = "{}:{}".format(guid, i)
+        original = await service.find_by_id(version_id)
         if original:
             return original
 
-    return app.data.find_one("items", req=None, _id=guid)
+    return await service.find_by_id(guid)
 
 
-def on_publish_item(app, item, is_new, **kwargs):
+async def on_publish_item(item: dict[str, Any], is_new: bool) -> None:
     """Populate stt department and version fields."""
     if item.get("subject"):
         for subject in item["subject"]:
@@ -53,20 +57,20 @@ def on_publish_item(app, item, is_new, **kwargs):
 
     # link the previous versions and update the id of the story
     if not is_new and "evolvedfrom" not in item:
-        original = get_previous_version(app, item["guid"], item["version"])
+        original = await get_previous_version(item["guid"], item["version"])
 
         if original:
-            if original.get("version") == item["version"]:
+            if original.version == item["version"]:
                 # the same version of the story been sent again so no need to create new version
                 return
 
-            service = superdesk.get_resource_service("content_api")
+            service = STTWireItem.get_service()
             new_id = "{}:{}".format(item["guid"], item["version"])
-            service.system_update(original["_id"], {"nextversion": new_id}, original)
+            await service.system_update(original.id, {"nextversion": new_id})
             item["guid"] = new_id
-            item["ancestors"] = copy(original.get("ancestors", []))
-            item["ancestors"].append(original["_id"])
-            item["bookmarks"] = original.get("bookmarks", [])
+
+            item["ancestors"] = copy(original.ancestors or []) + [original.id]
+            item["bookmarks"] = original.bookmarks or []
 
     # dump abstract
     for field in ("description_html", "description_text"):
@@ -75,18 +79,3 @@ def on_publish_item(app, item, is_new, **kwargs):
 
 def init_app(app):
     publish_item.connect(on_publish_item)
-
-    # add extra fields to elastic mapping
-    for field in STT_ROOT_FIELDS:
-        for resource in ("items", "content_api"):
-            app.config["DOMAIN"][resource]["schema"].update(
-                {
-                    field: {"type": "string", "mapping": not_analyzed},
-                }
-            )
-
-            app.config["SOURCES"][resource]["projection"].update(
-                {
-                    field: 1,
-                }
-            )

--- a/server/stt/signals.py
+++ b/server/stt/signals.py
@@ -1,7 +1,8 @@
+from typing import Any
 from newsroom.signals import publish_planning
 
 
-def set_planning_all_day(app, item, **kwargs):
+def set_planning_all_day(item: dict[str, Any], is_new: bool) -> None:
     item["dates"].setdefault("all_day", True)
 
 

--- a/server/stt/wire.py
+++ b/server/stt/wire.py
@@ -1,0 +1,24 @@
+from superdesk.core.app import SuperdeskAsyncApp
+from superdesk.core.resources import fields
+
+from newsroom.types import WireItem
+from newsroom.wire.module import module, wire_items_resource_config, init_module as init_wire_module
+
+__all__ = ["module", "STTWireItem"]
+
+
+class STTWireItem(WireItem):
+    sttdepartment: fields.Keyword | None = None
+    sttversion: fields.Keyword | None = None
+    sttgenre: fields.Keyword | None = None
+    sttdone1: fields.Keyword | None = None
+
+
+def init_module(app: SuperdeskAsyncApp) -> None:
+    init_wire_module(app)
+    # TODO-ASYNC: Fix hack needed to get around extending existing resource
+    WireItem.model_resource_name = STTWireItem.model_resource_name
+
+
+wire_items_resource_config.data_class = STTWireItem
+module.init = init_module

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,1 +1,1 @@
-from newsroom.tests.conftest import app, client  # noqa
+from newsroom.tests.conftest import app, client, runner, event_loop_policy  # noqa

--- a/server/tests/test_example.py
+++ b/server/tests/test_example.py
@@ -1,5 +1,0 @@
-def test_example():
-    """
-    Empty test to avoid pytest exit code in case of `no tests run`
-    """
-    assert True

--- a/server/tests/test_signals.py
+++ b/server/tests/test_signals.py
@@ -1,8 +1,8 @@
 from stt.signals import publish_planning, set_planning_all_day
 
 
-def test_publish_planning_signal():
+async def test_publish_planning_signal():
     publish_planning.connect(set_planning_all_day)
     item = {"dates": {"start": 1, "end": 1}}
-    publish_planning.send(None, item=item, foo=1)
+    await publish_planning.send(item, False)
     assert item["dates"]["all_day"] is True


### PR DESCRIPTION
### Purpose
Update STT Newshub next branch with the breaking changes from the Newshub v3.0 async version, specifically use of signals.

### What has changed
* Update package-lock.json/requirements.txt to the latest packages/modules
* Update mypy config to use Python v3.10 syntax
* Update usage of signals to the new async signal function signature
* Use new WireItem model & service instead of the deprecated get_resource_service
* Implement an STTWireItem model that adds STT specific fields on top of the WireItem model
* Update MODULES config to replace core wire module with the STT version