### PR TITLE
[STT-1301] Update filters and UI config to work with new metadata fields

### DIFF
--- a/server/data/ui_config.json
+++ b/server/data/ui_config.json
@@ -8,7 +8,7 @@
             },
             "subject" : {
                 "scheme" : [
-                    "mediatopic"
+                    "topics"
                 ]
             },
             "metadata_fields" : [

--- a/server/data/ui_config.json
+++ b/server/data/ui_config.json
@@ -16,11 +16,7 @@
                 [
                     "source",
                     "//",
-                    {
-                        "field": "service",
-                        "component": "service_names",
-                        "styles": { "fontWeight": "bold" }
-                    }
+                    "service"
                 ],
                 {
                     "field" : "sttversion",
@@ -41,11 +37,7 @@
             "metadata_fields" : [
                 "urgency",
                 "source",
-                {
-                    "field": "service",
-                    "component": "service_names",
-                    "styles": { "fontWeight": "bold" }
-                },
+                "service",
                 "sttversion",
                 "charcount",
                 "previous_versions",
@@ -62,11 +54,7 @@
             "metadata_fields" : [
                 "source",
                 "//",
-                {
-                    "field": "service",
-                    "component": "service_names",
-                    "styles": { "fontWeight": "bold" }
-                },
+                "service",
                 "//",
                 "sttversion",
                 "//",
@@ -75,11 +63,7 @@
                 "versioncreated"
             ],
             "compact_metadata_fields" : [
-                {
-                    "field": "service",
-                    "component": "service_names",
-                    "styles": { "fontWeight": "bold" }
-                },
+                "service",
                 "//",
                 "sttversion",
                 "//",

--- a/server/data/ui_config.json
+++ b/server/data/ui_config.json
@@ -1,44 +1,72 @@
 [
     {
         "_id": "wire",
-        "init_version": 5,
-        "preview": {
-            "slugline": {
-                "displayed": false
+        "init_version": 6,
+        "preview" : {
+            "slugline" : {
+                "displayed" : false
             },
-            "metadata_fields": [
-              "urgency",
-              ["source", "//", {"field": "sttdepartment", "styles": { "fontWeight": "bold" }}],
-              {
-                  "field": "sttversion",
-                  "component": "version_type"
-              },
-              ["charcount", "/", "wordcount"],
-              "previous_versions"
+            "subject" : {
+                "scheme" : [
+                    "mediatopic"
+                ]
+            },
+            "metadata_fields" : [
+                "urgency",
+                [
+                    "source",
+                    "//",
+                    {
+                        "field": "service",
+                        "component": "service_names",
+                        "styles": { "fontWeight": "bold" }
+                    }
+                ],
+                {
+                    "field" : "sttversion",
+                    "component" : "version_type"
+                },
+                [
+                    "charcount",
+                    "/",
+                    "wordcount"
+                ],
+                "previous_versions"
             ]
         },
-        "details": {
-            "slugline": {
-                "displayed": false
+        "details" : {
+            "slugline" : {
+                "displayed" : false
             },
-            "metadata_fields": [
-              "urgency",
-              "source",
-              {"field": "sttdepartment", "styles": { "fontWeight": "bold" }},
-              "sttversion",
-              "charcount",
-              "previous_versions",
-              "embargo"
+            "metadata_fields" : [
+                "urgency",
+                "source",
+                {
+                    "field": "service",
+                    "component": "service_names",
+                    "styles": { "fontWeight": "bold" }
+                },
+                "sttversion",
+                "charcount",
+                "previous_versions",
+                "embargo"
             ]
         },
-        "list": {
-            "highlights": {
-                "urgency": ["#C20000", "#BE8502"]
+        "list" : {
+            "highlights" : {
+                "urgency" : [
+                    "#C20000",
+                    "#BE8502"
+                ]
             },
-            "metadata_fields": [
+            "metadata_fields" : [
                 "source",
                 "//",
-                {"field": "sttdepartment", "styles": { "fontWeight": "bold" }},
+                {
+                    "field": "service",
+                    "component": "service_names",
+                    "styles": { "fontWeight": "bold" }
+                },
                 "//",
                 "sttversion",
                 "//",
@@ -46,8 +74,12 @@
                 "//",
                 "versioncreated"
             ],
-            "compact_metadata_fields": [
-                {"field": "sttdepartment", "styles": { "fontWeight": "bold" }},
+            "compact_metadata_fields" : [
+                {
+                    "field": "service",
+                    "component": "service_names",
+                    "styles": { "fontWeight": "bold" }
+                },
                 "//",
                 "sttversion",
                 "//",
@@ -55,10 +87,10 @@
                 "//",
                 "versioncreated"
             ],
-            "show_list_action_icons": {
-                "large": true,
-                "compact": true,
-                "mobile": false
+            "show_list_action_icons" : {
+                "large" : true,
+                "compact" : true,
+                "mobile" : false
             }
         },
         "advanced_search_tabs": {},

--- a/server/settings.py
+++ b/server/settings.py
@@ -47,7 +47,7 @@ AGENDA_GROUPS = [
         "nested": {
             "parent": "subject",
             "field": "scheme",
-            "value": "mediatopic",
+            "value": "topics",
             "include_planning": True,
         },
         "permissions": [],

--- a/server/settings.py
+++ b/server/settings.py
@@ -38,23 +38,16 @@ INSTALLED_APPS = [
 
 AGENDA_GROUPS = [
     {
-        "field": "sttdepartment",
+        "field": "service",
         "label": lazy_gettext("Department"),
-        "nested": {
-            "parent": "subject",
-            "field": "scheme",
-            "value": "sttdepartment",
-            "include_planning": True,
-        },
-        "permissions": [],
     },
     {
-        "field": "sttsubj",
+        "field": "subject",
         "label": lazy_gettext("Subject"),
         "nested": {
             "parent": "subject",
             "field": "scheme",
-            "value": "sttsubj",
+            "value": "mediatopic",
             "include_planning": True,
         },
         "permissions": [],
@@ -84,13 +77,8 @@ AGENDA_GROUPS = [
 
 WIRE_GROUPS = [
     {
-        "field": "sttdepartment",
+        "field": "service",
         "label": lazy_gettext("Department"),
-        "nested": {
-            "parent": "subject",
-            "field": "scheme",
-            "value": "sttdepartment",
-        },
     },
     {
         "field": "genre",
@@ -108,6 +96,7 @@ WIRE_GROUPS = [
 ]
 
 WIRE_AGGS = {
+    "service": {"terms": {"field": "service.name", "size": 100}},
     "genre": {"terms": {"field": "genre.name", "size": 50}},
     "_subject": {
         "terms": {"field": "subject.name", "size": 50}


### PR DESCRIPTION
- Updated `ui_config.json` and `settings.py` to use the `service` field instead of `sttdepartment` UI display and filtering. Adjusted metadata fields, group definitions, and aggregations to reflect this change, and updated related components and schemes accordingly. 
- Replaced `sttsubj` with `topics` in ui config too
- Adjusted `service` field to use the new component implemented in https://github.com/superdesk/newsroom-core/pull/1357

Depends on https://github.com/superdesk/newsroom-core/pull/1356, https://github.com/superdesk/newsroom-core/pull/1357 and https://github.com/superdesk/newsroom-app-stt/pull/244

Resolves: [STT-1301]

[STT-1301]: https://sofab.atlassian.net/browse/STT-1301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ