### PR TITLE
[STT-1223] Add query option to `remap_stt_metadata command

### DIFF
--- a/server/stt/commands/remap_stt_metadata.py
+++ b/server/stt/commands/remap_stt_metadata.py
@@ -4,6 +4,8 @@ import click
 
 from pathlib import Path
 
+from superdesk import json_utils
+
 from newsroom.commands.cli import newsroom_cli
 from newsroom.core import get_current_wsgi_app
 
@@ -131,11 +133,14 @@ def get_service_instance(resource):
     is_flag=True,
     help="Enable verbose output",
 )
-async def remap_stt_metadata(resources, limit, sleep_secs, dry_run, verbose):
-    await remap_stt_metadata_handler(resources, limit, sleep_secs, dry_run, verbose)
-
-
-async def remap_stt_metadata_handler(resources, limit, sleep_secs, dry_run, verbose):
+@click.option(
+    "--query",
+    type=str,
+    help="JSON query to filter items (will be passed as lookup parameter)",
+)
+async def remap_stt_metadata(
+    resources, limit, sleep_secs, dry_run, verbose, query=None
+):
     """
     Remap STT metadata fields for Wire and Agenda items in Newsroom.
 
@@ -146,7 +151,20 @@ async def remap_stt_metadata_handler(resources, limit, sleep_secs, dry_run, verb
       - Remapping the language field for STT metadata (fi/en)
 
     Supports dry-run mode, resource selection, batch processing, and verbosity.
+    Query parameter can be used to filter items using MongoDB query syntax.
+    If datetime fields are included in `query`, these should be in the same format
+    as `DATE_FORMAT` setting.
     """
+
+    await remap_stt_metadata_handler(
+        resources, limit, sleep_secs, dry_run, verbose, query
+    )
+
+
+async def remap_stt_metadata_handler(
+    resources, limit, sleep_secs, dry_run, verbose, query=None
+):
+    """Handler function to remap STT metadata fields."""
 
     BATCH_SIZE = 500
     topics_not_found = set()
@@ -155,12 +173,18 @@ async def remap_stt_metadata_handler(resources, limit, sleep_secs, dry_run, verb
     if isinstance(resources, tuple):
         resources = list(resources)
 
+    lookup = json_utils.loads(query) if query else None
+
     for resource in resources:
         print(f"Processing resource: '{resource}'")
         service = get_service_instance(resource)
         processed = 0
 
-        async for item in service.get_all_batch(size=BATCH_SIZE, max_iterations=10000):
+        async for item in service.get_all_batch(
+            size=BATCH_SIZE,
+            max_iterations=10000,
+            lookup=lookup,
+        ):
             item = item.to_dict()
             if limit != 0 and processed >= limit:
                 print(f"Reached limit of {limit} items for {resource}.")

--- a/server/tests/stt/commands/__init__.py
+++ b/server/tests/stt/commands/__init__.py
@@ -18,7 +18,7 @@ class FakeService:
         # store by _id for easier updates
         self._items = {i["_id"]: i for i in items}
 
-    async def get_all_batch(self, size=100, max_iterations=10000):
+    async def get_all_batch(self, size=100, max_iterations=10000, lookup=None):
         # simple paginator over current values, now async
         items = list(self._items.values())
         for i in range(0, min(len(items), size * max_iterations), size):


### PR DESCRIPTION
Introduces a `--query` CLI option to filter items using a JSON query, passed as a lookup parameter to the service. Updates handler logic to support the new query parameter for more flexible batch processing.

A couple of examples for the command with query: 

```bash
python manage.py remap_stt_metadata --resources items --limit 1000 --sleep-secs 0 --query '{"versioncreated": {"$gte": "2025-08-08T00:00:00+0000"}}'
```

```bash
python manage.py remap_stt_metadata --resources items --limit 1000 --sleep-secs 0 --query '{"versioncreated": {"$gte": "2025-01-01T00:00:00+0000", "$lte": "2025-12-31T23:59:59+0000"}}'
```

[STT-1223]

[STT-1223]: https://sofab.atlassian.net/browse/STT-1223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ