### PR TITLE
[STT-1301] Add `ui_config_patch` app for UI config resource workaround

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -33,6 +33,7 @@ INSTALLED_APPS = [
     "stt.external_links",
     "stt.filters",
     "stt.signals",
+    "stt.ui_config_patch",
     "newsroom.auth.saml",
 ]
 

--- a/server/stt/ui_config_patch.py
+++ b/server/stt/ui_config_patch.py
@@ -1,0 +1,17 @@
+import sys
+import superdesk
+
+from superdesk.resource import Resource
+
+
+class UiConfigWorkaround(Resource):
+    endpoint_name = "ui_config"
+
+
+def init_app(app) -> None:
+    # temporal workaround to register ui_config resource before initialize_data command
+    # as the new UI Config works async and the `initialize_data` command is not async compatible yet
+    if len(sys.argv) > 1 and sys.argv[1] == "initialize_data":
+        superdesk.register_resource(
+            "ui_config", UiConfigWorkaround, superdesk.Service, _app=app
+        )


### PR DESCRIPTION
### Purpose
Introduces the `stt.ui_config_patch` app and registers a temporary workaround to ensure the `ui_config` resource is available before the initialize_data command runs. This addresses async compatibility issues with the new UI Config and the initialize_data command.

This is a temporary workaround until we implement a proper fix for the initialize_data command to support both async and sync services.

[STT-1301]

[STT-1301]: https://sofab.atlassian.net/browse/STT-1301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ