### PR TITLE
[STT-1301] Refactor subject and service mapping in STT metadata

### DIFF
--- a/server/data/ui_config.json
+++ b/server/data/ui_config.json
@@ -108,7 +108,7 @@
     },
     {
         "_id": "agenda",
-        "init_version": 6,
+        "init_version": 7,
         "subnav": {
             "filters": [
                 "item_type",
@@ -130,6 +130,9 @@
             }
         },
         "preview": {
+            "subjects": {
+                "displayed": false
+            },
             "coverage_metadata_fields": [
                 "coverage_header",
                 "coverage_expected_date",

--- a/server/settings.py
+++ b/server/settings.py
@@ -42,7 +42,7 @@ AGENDA_GROUPS = [
         "label": lazy_gettext("Department"),
     },
     {
-        "field": "subject",
+        "field": "topics",
         "label": lazy_gettext("Subject"),
         "nested": {
             "parent": "subject",

--- a/server/stt/commands/remap_stt_metadata.py
+++ b/server/stt/commands/remap_stt_metadata.py
@@ -35,8 +35,12 @@ def reset_service(item, updates):
         updates["service"] = []
 
 
-def update_service(item, updates):
-    """Update `service` and `sttversion` from subject (sttdepartment)."""
+def remap_sttdepartment_to_service(item, updates):
+    """
+    Map 'sttdepartment' entries in the subject list to the 'service' field.
+    If no 'sttdepartment' is found, set a default service value.
+    Also sets the 'sttversion' field to 'Pika+'.
+    """
 
     subject = item.get("subject", [])
     for entry in subject:
@@ -52,11 +56,18 @@ def update_service(item, updates):
     updates["sttversion"] = "Pika+"
 
 
-def update_subject(item, updates, not_found):
-    """Update subject by mapping sttsubj to Media topics CV."""
+def remap_subject(item, updates, not_found):
+    """
+    - Update subject by mapping sttsubj to media topics.
+    - Removes any entry with scheme 'sttdepartment' as it was mapped to 'service'.
+    """
 
     subject = item.get("subject", [])
-    new_subjects = [entry for entry in subject if entry.get("scheme") != "sttsubj"]
+    new_subjects = [
+        entry
+        for entry in subject
+        if entry.get("scheme") not in ["sttsubj", "sttdepartment"]
+    ]
 
     for entry in subject:
         if entry.get("scheme") == "sttsubj":
@@ -192,8 +203,8 @@ async def remap_stt_metadata_handler(
 
             updates = {}
             reset_service(item, updates)
-            update_service(item, updates)
-            update_subject(item, updates, topics_not_found)
+            remap_sttdepartment_to_service(item, updates)
+            remap_subject(item, updates, topics_not_found)
             update_language(item, updates, resource)
 
             if not updates:


### PR DESCRIPTION
### What has changed
- Renamed and updated functions in remap_stt_metadata.py to clarify mapping of `sttdepartment` to `service`. 
- Improved subject filtering to eliminate entries with scheme equal to `sttsubj` and `sttdepartment` as they have been mapped accordingly. 
- Updated `settings.py` to use `topics` instead of `subject` for agenda groups. 
- Modified `ui_config.json` to increment agenda init_version and add `preview.subjects.displayed` flag.

Resolves: [STT-1301]

[STT-1301]: https://sofab.atlassian.net/browse/STT-1301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ