### PR TITLE
[STT-1428] config: Add Coverage schedule to Agenda PRIVATE_FIELDS

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -117,7 +117,7 @@ MODULES = [
     module
     for module in DEFAULT_MODULES
     if module not in ["newsroom.wire.module", "newsroom.monitoring.module"]
-] + ["stt.wire"]
+] + ["stt.wire", "stt.agenda"]
 
 LANGUAGES = ["fi", "en"]
 DEFAULT_LANGUAGE = "fi"

--- a/server/stt/agenda.py
+++ b/server/stt/agenda.py
@@ -4,9 +4,12 @@ from newsroom.agenda.filters import PRIVATE_FIELDS
 
 def init_module(app: SuperdeskAsyncApp):
     if "coverages.scheduled" not in PRIVATE_FIELDS:
-        PRIVATE_FIELDS.extend([
-            "coverages.scheduled",
-            "planning_items.coverages.planning.scheduled",
-        ])
+        PRIVATE_FIELDS.extend(
+            [
+                "coverages.scheduled",
+                "planning_items.coverages.planning.scheduled",
+            ]
+        )
+
 
 module = Module(name="stt.agenda", init=init_module)

--- a/server/stt/agenda.py
+++ b/server/stt/agenda.py
@@ -1,0 +1,12 @@
+from superdesk.core.module import Module, SuperdeskAsyncApp
+from newsroom.agenda.filters import PRIVATE_FIELDS
+
+
+def init_module(app: SuperdeskAsyncApp):
+    if "coverages.scheduled" not in PRIVATE_FIELDS:
+        PRIVATE_FIELDS.extend([
+            "coverages.scheduled",
+            "planning_items.coverages.planning.scheduled",
+        ])
+
+module = Module(name="stt.agenda", init=init_module)


### PR DESCRIPTION
### Purpose
Customer would not like the Coverage schedules to be shown to end users (not used in their external workflows)

### What has changed
* Add/load new STT Agenda module
* Add Coverage schedule fields to the Agenda PRIVATE_FIELDS attribute

Resolves: [STT-1428](https://sofab.atlassian.net/browse/STT-1428)

[STT-1428]: https://sofab.atlassian.net/browse/STT-1428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ